### PR TITLE
Fixup make_vulkan

### DIFF
--- a/emulators/wine-proton/Makefile
+++ b/emulators/wine-proton/Makefile
@@ -129,7 +129,7 @@ PLIST_SUB+=	WINE32="" WINE64="@comment " WINEARCH="i386"
 .endif
 
 pre-configure:
-	cd ${WRKSRC} && ${PYTHON_CMD} dlls/winevulkan/make_vulkan --xml vk.xml
+	cd ${WRKSRC} && ${SETENV} ${MAKE_ENV} ${PYTHON_CMD} dlls/winevulkan/make_vulkan --xml vk.xml --video-xml video.xml
 	cd ${WRKSRC} && ${PERL5} tools/make_specfiles
 
 pre-build:


### PR DESCRIPTION
This would allow the build to work fine inside poudriere.

When the `video.xml` file is not specified, the `make_vulkan` script will try to verify if the file already exists in a cache folder, and if not will download from the network a file and try to use it.

This path allow to use the already existing `video.xml` file.